### PR TITLE
Add GitHub CI for multiplatform artifacts

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,56 @@
+name: Build Artifacts
+
+on:
+  push:
+    branches: [ "master" ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build - ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_name: rdupes
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary_name: rdupes
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary_name: rdupes
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary_name: rdupes.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rdupes-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/${{ matrix.binary_name }}
+          if-no-files-found: error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::collections::{HashMap, HashSet};
 use std::io::{Read, SeekFrom};
 #[cfg(unix)]
-use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::MetadataExt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -211,7 +211,7 @@ impl DupeFinder {
                 size_pbar.update(metadata.len() as usize).unwrap();
 
                 #[cfg(unix)]
-                let new_inode = inodes.insert(metadata.st_ino());
+                let new_inode = inodes.insert(metadata.ino());
                 #[cfg(not(unix))]
                 let new_inode = true;
 


### PR DESCRIPTION
Added a new GitHub Actions workflow to build release binaries for multiple platforms (Linux, macOS Intel/Silicon, Windows) and upload them as artifacts for download. The workflow is configured to run on pushes to the master branch and on tags.

Close #2 

---
*PR created automatically by Jules for task [11825938529174243302](https://jules.google.com/task/11825938529174243302) started by @erikreed*