### PR TITLE
Fix hard link duplicate detection bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "kdam",
  "log",
  "mimalloc",
+ "serde",
  "simple_logger",
  "tinyvec",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "mimalloc",
  "serde",
  "simple_logger",
+ "tempfile",
  "tinyvec",
  "tokio",
  "tokio-task-tracker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arrayref"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +756,7 @@ dependencies = [
 name = "rdupes"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-fs",
  "blake3",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "arrayref"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,7 +750,6 @@ dependencies = [
 name = "rdupes"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-fs",
  "blake3",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "A rust port of pydupes. Super fast."
 
 
 [dependencies]
+anyhow = "1.0"
 async-fs = "2.1"
 blake3 = { version = "1.5", features = ["mmap"] }
 ciborium = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ tokio-task-tracker = "1.3"
 tokio-util = "0.7"
 walkdir = "2.5"
 
+[dev-dependencies]
+tempfile = "3.12.0"
+
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ futures-lite = "2.3"
 humansize = "2.1"
 kdam = "0.5"
 log = { features = ['release_max_level_info'], version = "0.4" }
+serde = { version = "1.0", features = ["derive"] }
 mimalloc = { version = "0.1", default-features = false }
 simple_logger = { features = ['stderr'], version = "4.3" }
 tinyvec = { version = "1.8.0", features = ["alloc", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ description = "A rust port of pydupes. Super fast."
 
 
 [dependencies]
-anyhow = "1.0"
 async-fs = "2.1"
 blake3 = { version = "1.5", features = ["mmap"] }
 ciborium = "0.2.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[cfg(not(unix))]
-use std::collections::HashMap;
-#[cfg(unix)]
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use std::io::{Read, SeekFrom};
@@ -204,7 +201,10 @@ impl DupeFinder {
             let mut size_map = SizeMap::new();
             let mut n = 0u64;
             let mut n_filtered = 0u64;
+            #[cfg(unix)]
             let mut n_hardlinks = 0u64;
+            #[cfg(not(unix))]
+            let n_hardlinks = 0u64;
             let mut size_total = 0u64;
 
             let mut file_pbar = tqdm!(desc = "Traversing files", position = 0, unit = " file");
@@ -459,10 +459,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(test_dir);
         std::fs::create_dir_all(test_dir).unwrap();
 
-        let f1 = format!("{}/file1", test_dir);
-        let f1_hl = format!("{}/file1_hl", test_dir);
-        let f2 = format!("{}/file2", test_dir);
-        let f2_hl = format!("{}/file2_hl", test_dir);
+        let f1 = std::path::Path::new(test_dir).join("file1").to_string_lossy().to_string();
+        let f1_hl = std::path::Path::new(test_dir).join("file1_hl").to_string_lossy().to_string();
+        let f2 = std::path::Path::new(test_dir).join("file2").to_string_lossy().to_string();
+        let f2_hl = std::path::Path::new(test_dir).join("file2_hl").to_string_lossy().to_string();
 
         std::fs::write(&f1, b"common content").unwrap();
         std::fs::hard_link(&f1, &f1_hl).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use std::io::{Read, SeekFrom};
@@ -104,10 +103,9 @@ impl DupeProgress {
         }
     }
 
-    fn update(&mut self, size: usize) -> anyhow::Result<()> {
-        self.pbar_count.update(1).context("Failed to update count progress bar")?;
-        self.pbar_size.update(size).context("Failed to update size progress bar")?;
-        Ok(())
+    fn update(&mut self, size: usize) {
+        self.pbar_count.update(1).unwrap();
+        self.pbar_size.update(size).unwrap();
     }
 }
 
@@ -123,8 +121,8 @@ impl DupeFinder {
         }
     }
 
-    async fn hash_file_chunk(&self, path: &str, front: bool, fsize: u64) -> anyhow::Result<Hash> {
-        let f = File::open(path).await.with_context(|| format!("Failed to open {}", path))?;
+    async fn hash_file_chunk(&self, path: &str, front: bool, fsize: u64) -> std::io::Result<Hash> {
+        let f = File::open(path).await?;
 
         let mut reader = BufReader::new(f);
         let bufsize = EDGE_SIZE.min(self.min_file_size as usize);
@@ -133,10 +131,10 @@ impl DupeFinder {
 
         if !front && fsize > EDGE_SIZE as u64 {
             let pos = fsize - EDGE_SIZE as u64;
-            reader.seek(SeekFrom::Start(pos)).await.context("Failed to seek")?;
+            reader.seek(SeekFrom::Start(pos)).await.unwrap();
         }
 
-        let n = reader.read(&mut buf).await.context("Failed to read")?;
+        let n = reader.read(&mut buf).await?;
 
         let hash = blake3::hash(&buf[0..n]);
         Ok(*hash.as_bytes())
@@ -147,7 +145,7 @@ impl DupeFinder {
         fsize: u64,
         groups: I,
         mode: PathCheckMode,
-    ) -> anyhow::Result<HashMap<Hash, TinyVec<[PathGroup; 2]>>>
+    ) -> HashMap<Hash, TinyVec<[PathGroup; 2]>>
     where
         I: IntoIterator<Item = PathGroup>,
     {
@@ -158,33 +156,30 @@ impl DupeFinder {
             .map(|group| {
                 let df = self.clone();
                 tokio::spawn(async move {
-                    let _permit = df
-                        .read_semaphore
-                        .acquire()
-                        .await
-                        .context("Failed to acquire read semaphore")?;
+                    let _permit = df.read_semaphore.acquire().await.unwrap();
                     let p = group.paths[0].clone();
                     let hash = match mode {
                         PathCheckMode::Start => df.hash_file_chunk(&p, true, fsize).await,
                         PathCheckMode::End => df.hash_file_chunk(&p, false, fsize).await,
-                        PathCheckMode::Full => tokio::task::spawn_blocking(move || {
-                            if df.disable_mmap {
-                                hash_file(&p)
-                            } else {
-                                hash_mmap_file(&p)
-                            }
-                        })
-                        .await
-                        .context("Full hash task panicked")
-                        .map(|res| res.map_err(anyhow::Error::from))?,
+                        PathCheckMode::Full => {
+                            tokio::task::spawn_blocking(move || {
+                                if df.disable_mmap {
+                                    hash_file(&p)
+                                } else {
+                                    hash_mmap_file(&p)
+                                }
+                            })
+                            .await
+                            .unwrap()
+                        }
                     };
-                    Ok::<_, anyhow::Error>((group, hash))
+                    (group, hash)
                 })
             })
             .collect::<FuturesUnordered<_>>()
             .into_iter()
         {
-            let (group, hash) = task.await.context("Dedupe task panicked")??;
+            let (group, hash) = task.await.unwrap();
             match hash {
                 Ok(hash) => {
                     candidates.entry(hash).or_default().push(group);
@@ -192,13 +187,13 @@ impl DupeFinder {
                 Err(e) => warn!("Failed to hash {}: {}", group.paths[0], e),
             }
         }
-        Ok(candidates)
+        candidates
     }
 
     pub async fn traverse_paths(
         &self,
         paths: Vec<String>,
-    ) -> anyhow::Result<SizeMap> {
+    ) -> Result<SizeMap, std::io::Error> {
         let now = Instant::now();
         let (tx, mut rx) = mpsc::channel::<(String, std::fs::Metadata)>(1024);
 
@@ -224,12 +219,8 @@ impl DupeFinder {
                 unit_scale = true
             );
             while let Some((path, metadata)) = rx.recv().await {
-                file_pbar
-                    .update(1)
-                    .context("Failed to update file progress bar")?;
-                size_pbar
-                    .update(metadata.len() as usize)
-                    .context("Failed to update size progress bar")?;
+                file_pbar.update(1).unwrap();
+                size_pbar.update(metadata.len() as usize).unwrap();
 
                 let fsize = metadata.len();
                 #[cfg(unix)]
@@ -289,7 +280,7 @@ impl DupeFinder {
                     format_size(largest.0 * largest.1.len() as u64, BINARY)
                 )
             }
-            Ok::<SizeMap, anyhow::Error>(size_map)
+            size_map
         });
 
         let num_directories = Arc::new(AtomicU64::new(0));
@@ -341,7 +332,7 @@ impl DupeFinder {
         info!("Directories traversed: {:?}", num_directories);
         info!("Errors during traversal: {:?}", errors);
 
-        let size_map = handle.await.context("Traversal handle panicked")??;
+        let size_map = handle.await?;
         info!(
             "Traversal completed in: {:.1}s",
             now.elapsed().as_secs_f32()
@@ -354,7 +345,7 @@ impl DupeFinder {
         &self,
         size_map: SizeMap,
         dupes_tx: Sender<DupeSet>,
-    ) -> anyhow::Result<()> {
+    ) -> std::io::Result<()> {
         let (spawner, waiter) = tokio_task_tracker::new();
         let pbar = Arc::new(Mutex::new(DupeProgress::new(&size_map)));
         let task_semaphore = Arc::new(Semaphore::new(self.read_concurrency.max(4)));
@@ -368,53 +359,42 @@ impl DupeFinder {
             spawner.spawn(|tracker| async move {
                 let _tracker = tracker;
 
-                let res = async {
-                    let candidates = df.dedupe_paths(fsize, groups, PathCheckMode::Start).await?;
+                let candidates = df.dedupe_paths(fsize, groups, PathCheckMode::Start).await;
 
-                    for fgroups in candidates.into_values() {
-                        if fgroups.len() > 1 {
-                            let candidates =
-                                df.dedupe_paths(fsize, fgroups, PathCheckMode::End).await?;
-                            for bgroups in candidates.into_values() {
-                                if bgroups.len() > 1 {
-                                    let candidates = df
-                                        .dedupe_paths(fsize, bgroups, PathCheckMode::Full)
-                                        .await?;
-                                    for dupes in candidates.into_values() {
-                                        if dupes.len() > 1 {
-                                            debug!("Dupes found: {:?}", dupes);
-                                            let num_groups = dupes.len();
-                                            let all_paths: Vec<String> =
-                                                dupes.into_iter().flat_map(|g| g.paths).collect();
-                                            df.dupe_files.fetch_add(
-                                                (all_paths.len() - 1) as u64,
-                                                Ordering::Relaxed,
-                                            );
-                                            df.dupe_sizes.fetch_add(
-                                                (num_groups - 1) as u64 * fsize,
-                                                Ordering::Relaxed,
-                                            );
-                                            let _ = dupes_tx
-                                                .send(DupeSet {
-                                                    fsize,
-                                                    paths: all_paths,
-                                                })
-                                                .await;
-                                        }
+                for fgroups in candidates.into_values() {
+                    if fgroups.len() > 1 {
+                        let candidates = df.dedupe_paths(fsize, fgroups, PathCheckMode::End).await;
+                        for bgroups in candidates.into_values() {
+                            if bgroups.len() > 1 {
+                                let candidates =
+                                    df.dedupe_paths(fsize, bgroups, PathCheckMode::Full).await;
+                                for dupes in candidates.into_values() {
+                                    if dupes.len() > 1 {
+                                        debug!("Dupes found: {:?}", dupes);
+                                        let num_groups = dupes.len();
+                                        let all_paths: Vec<String> =
+                                            dupes.into_iter().flat_map(|g| g.paths).collect();
+                                        df.dupe_files.fetch_add(
+                                            (all_paths.len() - 1) as u64,
+                                            Ordering::Relaxed,
+                                        );
+                                        df.dupe_sizes.fetch_add(
+                                            (num_groups - 1) as u64 * fsize,
+                                            Ordering::Relaxed,
+                                        );
+                                        let _ = dupes_tx
+                                            .send(DupeSet {
+                                                fsize,
+                                                paths: all_paths,
+                                            })
+                                            .await;
                                     }
                                 }
                             }
                         }
                     }
-                    Ok::<(), anyhow::Error>(())
                 }
-                .await;
-
-                if let Err(e) = res {
-                    error!("Failed to dedupe files of size {}: {}", fsize, e);
-                }
-
-                let _ = pbar.lock().await.update(fsize as usize);
+                pbar.lock().await.update(fsize as usize);
                 drop(permit); // move permit into the tokio thread
             });
         }
@@ -479,8 +459,8 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn hard_link_duplicates() -> anyhow::Result<()> {
-        let temp = tempfile::tempdir().context("Failed to create temp dir")?;
+    async fn hard_link_duplicates() {
+        let temp = tempfile::tempdir().unwrap();
         let test_dir = temp.path();
 
         let f1 = test_dir.join("file1").to_string_lossy().to_string();
@@ -488,10 +468,10 @@ mod tests {
         let f2 = test_dir.join("file2").to_string_lossy().to_string();
         let f2_hl = test_dir.join("file2_hl").to_string_lossy().to_string();
 
-        std::fs::write(&f1, b"common content").context("Failed to write f1")?;
-        std::fs::hard_link(&f1, &f1_hl).context("Failed to link f1_hl")?;
-        std::fs::write(&f2, b"common content").context("Failed to write f2")?;
-        std::fs::hard_link(&f2, &f2_hl).context("Failed to link f2_hl")?;
+        std::fs::write(&f1, b"common content").unwrap();
+        std::fs::hard_link(&f1, &f1_hl).unwrap();
+        std::fs::write(&f2, b"common content").unwrap();
+        std::fs::hard_link(&f2, &f2_hl).unwrap();
 
         let df = DupeFinder::new(DupeParams {
             min_file_size: 0,
@@ -502,10 +482,10 @@ mod tests {
         let size_map = df
             .traverse_paths(vec![test_dir.to_string_lossy().to_string()])
             .await
-            .context("Failed to traverse paths")?;
+            .unwrap();
         let (tx, mut rx) = mpsc::channel(10);
 
-        df.check_hashes_and_content(size_map, tx).await.context("Failed to check hashes")?;
+        df.check_hashes_and_content(size_map, tx).await.unwrap();
 
         let mut all_paths = Vec::new();
         while let Some(ds) = rx.recv().await {
@@ -520,8 +500,7 @@ mod tests {
 
         assert_eq!(all_paths, expected);
 
-        std::fs::remove_dir_all(test_dir).context("Failed to remove test dir")?;
-        Ok(())
+        std::fs::remove_dir_all(test_dir).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,11 +467,13 @@ mod tests {
         let f1_hl = test_dir.join("file1_hl").to_string_lossy().to_string();
         let f2 = test_dir.join("file2").to_string_lossy().to_string();
         let f2_hl = test_dir.join("file2_hl").to_string_lossy().to_string();
+        let f3 = test_dir.join("file3").to_string_lossy().to_string();
 
         std::fs::write(&f1, b"common content").unwrap();
         std::fs::hard_link(&f1, &f1_hl).unwrap();
         std::fs::write(&f2, b"common content").unwrap();
         std::fs::hard_link(&f2, &f2_hl).unwrap();
+        std::fs::write(&f3, b"uncommon content").unwrap();
 
         let df = DupeFinder::new(DupeParams {
             min_file_size: 0,


### PR DESCRIPTION
This change fixes a bug where hard links to the same data were being skipped during duplicate detection. By grouping paths by inode, we now correctly identify all duplicate paths across multiple sets of hard links while still maintaining efficient hashing (only one hash per unique physical data).

Key changes:
- `PathGroup` struct added to `src/lib.rs` to keep track of paths per inode.
- `SizeMap` updated to use `Vec<PathGroup>`.
- `traverse_paths` modified to populate `PathGroup`s.
- `dedupe_paths` and `check_hashes_and_content` updated to handle grouped paths and report all of them.
- `serde` added to `Cargo.toml` for checkpointing support.

---
*PR created automatically by Jules for task [7711427948565529074](https://jules.google.com/task/7711427948565529074) started by @erikreed*