### PR TITLE
Add GitHub Action for test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,8 +23,8 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Generate HTML report and show summary
         run: |
-          cargo llvm-cov report --all-features --workspace --html
-          cargo llvm-cov report --all-features --workspace
+          cargo llvm-cov report --html
+          cargo llvm-cov report
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,38 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Generate HTML report and show summary
+        run: |
+          cargo llvm-cov report --all-features --workspace --html
+          cargo llvm-cov report --all-features --workspace
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          use_oidc: true
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-report
+          path: target/llvm-cov/html


### PR DESCRIPTION
This change adds a new GitHub Action workflow that calculates and reports test coverage for the project. It uses `cargo-llvm-cov` to generate coverage data, which is then uploaded to Codecov and also made available as a downloadable HTML report artifact. A summary table is also printed to the workflow logs for easy access.

---
*PR created automatically by Jules for task [11844935738324081577](https://jules.google.com/task/11844935738324081577) started by @erikreed*